### PR TITLE
Add Palo Alto Networks DNS Sinkhole detection

### DIFF
--- a/chkdm
+++ b/chkdm
@@ -80,6 +80,8 @@ adblockDNS[AhaDNS]="5.2.75.75"
 adblockDNS[CONTROL D]="76.76.2.2"
 adblockDNS[dnsforge.de]="176.9.93.198"
 
+PaloAltoSinkholeCname="sinkhole.paloaltonetworks.com."
+
 function query() {
     domain="$1"
     dns="$2"
@@ -87,7 +89,9 @@ function query() {
 
     result="$(dig +short "$domain" @"$dns" | head -n 1)"
 
-    if [ "filterDetect" != "$filterDetect" ]; then
+    if [ "$PaloAltoSinkholeCname" = "$result" ]; then
+        return 2
+    elif [ "filterDetect" != "$filterDetect" ]; then
         test "" != "$result"
         return $?
     fi
@@ -136,6 +140,8 @@ function chkDomain() {
     elif [ "1" = "$queryStatus" ]; then
         echo.Red "Failed!"
         detailQuery "$domain" "$dns"
+    elif [ "2" = "$queryStatus" ]; then
+        echo.Red "Palo Alto DNS Sinkhole detected!"
     else
         error "Unknown error"
     fi


### PR DESCRIPTION
Palo Alto Networks firewall can intercept the DNS query, and then forge response for known malicious domain, which will cause the result to be inaccurate(All "OK!" False-negative).

Though the DNS Sinkholed result can be changed to any IP address, by default, response for A/AAAA response query will be this CNAME domain: `sinkhole.paloaltonetworks.com.`, which is a recognizable pattern, so we can detect it, and show some prompt message.

Using `a.anticrsss1-ep.xyz` as a test target under Palo Alto Networks firewall DNS Sinkhole enabled environment:

| **Before** | **After** | 
| ---------- | --------- |
| False result | PA DNS Sinkhole detected |
| ![image](https://user-images.githubusercontent.com/3691490/192164414-7dc40d83-e775-4411-a127-5ca34ea57907.png) | ![image](https://user-images.githubusercontent.com/3691490/192163998-6ba2d77b-3518-480d-9180-8007bd6ea6ab.png) |

This PR fixes #1