### PR TITLE
Issue 12 ✨ add availability to add additional DNS resolvers via file chkdm.additional_dns

### DIFF
--- a/chkdm
+++ b/chkdm
@@ -91,6 +91,10 @@ adblockDNS[dnsforge.de]="176.9.93.198"
 adblockDNS[OVPN]="192.165.9.157"
 adblockDNS[Tiarap]="188.166.206.224"
 
+# Not following: chkdm.additional_dns was not specified as input (see shellcheck -x). [SC1091]
+# shellcheck disable=SC1091
+[ -f chkdm.additional_dns ] && . chkdm.additional_dns
+
 PaloAltoSinkholeCname="sinkhole.paloaltonetworks.com."
 NextDNSBlockPageCname="blockpage.nextdns.io."
 NextDNSBlockPageIP="$(dig +short $NextDNSBlockPageCname)"


### PR DESCRIPTION
This PR solves issue #12.

See some examples:

querying a domain that should not be blocked anywhere:
<details><pre>
🦎🖥  ✔ ~/temp/PRs/fork-chkdomain [issue_12_additional_dns|…1]
16:33 $ ./chkdm web.de
You are checking domain: web.de

Running dig/nslookup over 14 nofilter DNS:
 - AdGuard (94.140.14.140) ... OK! (82.165.229.83 82.165.229.138)
 - Cloudflare (1.1.1.1) ... OK! (82.165.229.138 82.165.229.83)
 - DigitalCourage e.V (46.182.19.48) ... OK! (82.165.229.138 82.165.229.83)
 - dns0.eu (185.253.5.0) ... OK! (82.165.229.83 82.165.229.138)
 - dnsforge.de (176.9.93.198) ... OK! (82.165.229.138 82.165.229.83)
 - Freenom World (80.80.81.81) ... OK! (82.165.229.138 82.165.229.83)
 - Freifunk Munich (5.1.66.255) ... OK! (82.165.229.83 82.165.229.138)
 - Google (8.8.8.8) ... OK! (82.165.229.83 82.165.229.138)
 - Hinet (168.95.1.1) ... OK! (82.165.229.138 82.165.229.83)
 - Njalla.se (95.215.19.53) ... OK! (82.165.229.138 82.165.229.83)
 - OpenDNS (208.67.222.2) ... OK! (82.165.229.83 82.165.229.138)
 - Quad9 (9.9.9.10) ... OK! (82.165.229.138 82.165.229.83)
 - UltraDNS (64.6.64.6) ... OK! (82.165.229.138 82.165.229.83)
 - Yandex (77.88.8.1) ... OK! (82.165.229.83 82.165.229.138)

Running dig/nslookup over 11 secure DNS:
 - CleanBrowsing (185.228.168.9) ... OK! (82.165.229.83 82.165.229.138)
 - Cloudflare (1.1.1.2) ... OK! (82.165.229.83 82.165.229.138)
 - Comodo (8.26.56.26) ... OK! (;; connection timed out; no servers could be reached)
 - CONTROL D (76.76.2.1) ... OK! (82.165.229.138 82.165.229.83)
 - dns0.eu (193.110.81.0) ... OK! (82.165.229.138 82.165.229.83)
 - OpenDNS (208.67.222.222) ... OK! (82.165.229.83 82.165.229.138)
 - Quad101 (101.101.101.101) ... OK! (82.165.229.83 82.165.229.138)
 - Quad9 (9.9.9.9) ... OK! (82.165.229.83 82.165.229.138)
 - SafeDNS (195.46.39.39) ... OK! (82.165.229.83 82.165.229.138)
 - UltraDNS (156.154.70.2) ... OK! (82.165.229.83 82.165.229.138)
 - Yandex (77.88.8.2) ... OK! (82.165.229.83 82.165.229.138)

Running dig/nslookup over 10 AD(and tracker)-blocking DNS:
 - 1Hosts (76.76.2.38) ... OK! (82.165.229.83 82.165.229.138)
 - AdGuard (94.140.14.14) ... OK! (82.165.229.83 82.165.229.138)
 - AhaDNS (5.2.75.75) ... OK! (82.165.229.83 82.165.229.138)
 - clean.dnsforge.de (49.12.223.2) ... OK! (82.165.229.138 82.165.229.83)
 - CONTROL D (76.76.2.2) ... OK! (82.165.229.83 82.165.229.138)
 - dismail.de (80.241.218.68) ... OK! (82.165.229.138 82.165.229.83)
 - dns0.eu zero (193.110.81.9) ... OK! (82.165.229.83 82.165.229.138)
 - NextDNS.io (45.90.28.39) ... OK! (82.165.229.83 82.165.229.138)
 - OVPN (192.165.9.157) ... OK! (82.165.229.83 82.165.229.138)
 - Quad9 (9.9.9.11) ... OK! (82.165.229.138 82.165.229.83)

Running nslookup default DNS (127.0.0.1):
 - 127.0.0.1 ... OK! (82.165.229.83 82.165.229.138)

Get more intels about this domain from:
AlienVault Open Threat Exchange
  - https://otx.alienvault.com/indicator/domain/web.de
Bitdefender TrafficLight
  - https://trafficlight.bitdefender.com/info/?url=https%3A%2F%2Fweb.de
Google Safe Browsing
  - https://transparencyreport.google.com/safe-browsing/search?url=web.de
Kaspersky Threat Intelligence Portal
  - https://opentip.kaspersky.com/web.de?tab=web
McAfee SiteAdvisor
  - https://siteadvisor.com/sitereport.html?url=web.de
Norton Safe Web
  - https://safeweb.norton.com/report/show?url=web.de
OpenDNS
  - https://domain.opendns.com/web.de
URLVoid
  - https://www.urlvoid.com/scan/web.de/
urlscan.io
  - https://urlscan.io/domain/web.de
VirusTotal
  - https://www.virustotal.com/en/domain/web.de/information/
Yandex Site safety report
  - https://yandex.com/safety/?l10n=en&url=web.de
</pre></details>

querying a domain that should be blocked somewhere:
<details><pre>
🦎🖥  ✔ ~/temp/PRs/fork-chkdomain [issue_12_additional_dns|…1]
16:33 $ ./chkdm telemetry.dropbox.com
You are checking domain: telemetry.dropbox.com

Running dig/nslookup over 14 nofilter DNS:
 - AdGuard (94.140.14.140) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - Cloudflare (1.1.1.1) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - DigitalCourage e.V (46.182.19.48) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - dns0.eu (185.253.5.0) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - dnsforge.de (176.9.93.198) ... Failed!
   Address: 0.0.0.0
   Address: ::
 - Freenom World (80.80.81.81) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - Freifunk Munich (5.1.66.255) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - Google (8.8.8.8) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - Hinet (168.95.1.1) ... OK! (telemetry.v.dropbox.com. 162.125.35.136)
 - Njalla.se (95.215.19.53) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - OpenDNS (208.67.222.2) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - Quad9 (9.9.9.10) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - UltraDNS (64.6.64.6) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - Yandex (77.88.8.1) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)

Running dig/nslookup over 11 secure DNS:
 - CleanBrowsing (185.228.168.9) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - Cloudflare (1.1.1.2) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - Comodo (8.26.56.26) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - CONTROL D (76.76.2.1) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - dns0.eu (193.110.81.0) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - OpenDNS (208.67.222.222) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - Quad101 (101.101.101.101) ... OK! (telemetry.v.dropbox.com. 162.125.35.136)
 - Quad9 (9.9.9.9) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - SafeDNS (195.46.39.39) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - UltraDNS (156.154.70.2) ... OK! (telemetry.v.dropbox.com. 162.125.21.2)
 - Yandex (77.88.8.2) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)

Running dig/nslookup over 10 AD(and tracker)-blocking DNS:
 - 1Hosts (76.76.2.38) ... NextDNS Block Page detected!
 - AdGuard (94.140.14.14) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - AhaDNS (5.2.75.75) ... Failed!
   ** server can't find telemetry.dropbox.com: REFUSED
 - clean.dnsforge.de (49.12.223.2) ... Failed!
   Address: 0.0.0.0
   Address: ::
 - CONTROL D (76.76.2.2) ... NextDNS Block Page detected!
 - dismail.de (80.241.218.68) ... NextDNS Block Page detected!
 - dns0.eu zero (193.110.81.9) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - NextDNS.io (45.90.28.39) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)
 - OVPN (192.165.9.157) ... NextDNS Block Page detected!
 - Quad9 (9.9.9.11) ... OK! (telemetry.v.dropbox.com. 162.125.20.2)

Running nslookup default DNS (127.0.0.1):
 - 127.0.0.1 ... NextDNS Block Page detected!

Get more intels about this domain from:
AlienVault Open Threat Exchange
  - https://otx.alienvault.com/indicator/domain/telemetry.dropbox.com
Bitdefender TrafficLight
  - https://trafficlight.bitdefender.com/info/?url=https%3A%2F%2Ftelemetry.dropbox.com
Google Safe Browsing
  - https://transparencyreport.google.com/safe-browsing/search?url=telemetry.dropbox.com
Kaspersky Threat Intelligence Portal
  - https://opentip.kaspersky.com/telemetry.dropbox.com?tab=web
McAfee SiteAdvisor
  - https://siteadvisor.com/sitereport.html?url=telemetry.dropbox.com
Norton Safe Web
  - https://safeweb.norton.com/report/show?url=telemetry.dropbox.com
OpenDNS
  - https://domain.opendns.com/telemetry.dropbox.com
URLVoid
  - https://www.urlvoid.com/scan/telemetry.dropbox.com/
urlscan.io
  - https://urlscan.io/domain/telemetry.dropbox.com
VirusTotal
  - https://www.virustotal.com/en/domain/telemetry.dropbox.com/information/
Yandex Site safety report
  - https://yandex.com/safety/?l10n=en&url=telemetry.dropbox.com
</pre></details>
