### PR TITLE
Support Custom DNS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,11 @@ jobs:
     before_script:
       - echo $PATH
       - type bash && bash --version
+      - echo -e '8.8.4.4\n1.0.0.1\n1.1' > CustomDNS.txt
+      - echo -e '223.5.5.5\n114.114.114.114' > CustomDNS2.txt
     script:
       - ./chkdm dnslow.me
+      - CustomDNSFile=./CustomDNS2.txt ./chkdm dnslow.me
 
   - stage: Ubuntu test
     env:
@@ -53,8 +56,11 @@ jobs:
       - brew info bash
       - which bash
       - env bash --version
+      - echo -e '8.8.4.4\n1.0.0.1\n1.1' > CustomDNS.txt
+      - echo -e '223.5.5.5\n114.114.114.114' > CustomDNS2.txt
     script:
       - ./chkdm dnslow.me
+      - CustomDNSFile=./CustomDNS2.txt ./chkdm dnslow.me
 
   - stage: macOS test
     os: osx

--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ $ ./chkdm <domain name>
 
 Additionally, you can put the script in your `$PATH`, such as `/usr/local/bin`, to make it executable from anywhere.
 
+### Using Custom DNS
+
+For custom DNS checks, create `CustomDNS.txt` in the script's directory, listing your DNS server IPs. Use # for comments:
+
+```txt
+127.0.0.1
+192.168.1.1       # Local DNS
+168.95.192.1      # Hinet DNS
+```
+
+If you wish to use a custom file location, you can specify a custom file using `CustomDNSFile` variable before executing:
+
+```sh
+CustomDNSFile="/path/to/your/dnsfile.txt" ./chkdm ipinfo.tw
+```
+
+The script will then include these servers in its checks and provide results.
+
 ## Screenshot
 
 ![Screenshot](chkdomain.png)
@@ -70,12 +88,14 @@ Only a few command-line tools are needed:
 - awk
 - bash
 - dig
+- dirname
 - head
 - nslookup
+- readlink
 - sed
 - sort
 
-Most of the commands (`awk`, `bash`, `head`, `sed`, and `sort`) come pre-installed on common Linux distributions. To install `dig` and `nslookup`, use your package manager (e.g., `apt`, `yum`, `pacman`) to install the `dnsutils` (Debian/Ubuntu) or `bind-utils` (RHEL/CentOS, Arch/Manjaro) package.
+Most of the commands (`awk`, `bash`, `dirname`, `head`, `readlink`, `sed`, and `sort`) come pre-installed on common Linux distributions. To install `dig` and `nslookup`, use your package manager (e.g., `apt`, `yum`, `pacman`) to install the `dnsutils` (Debian/Ubuntu) or `bind-utils` (RHEL/CentOS, Arch/Manjaro) package.
 
 ## Notice
 

--- a/chkdm
+++ b/chkdm
@@ -49,7 +49,7 @@ if [ "$#" -ne "1" ]; then
     exit 1
 fi
 
-for cmd in dig nslookup sed head awk sort; do
+for cmd in dig nslookup sed head awk sort dirname readlink; do
     if ! command -v $cmd > /dev/null 2>&1; then
         error "command: $cmd not found!"
     fi
@@ -219,6 +219,20 @@ function checkDefaultDNS() {
     chkDomain "$domain" "$defaultDNS" filterDetect
 }
 
+function checkCustomDNS() {
+    DefaultCustomDNSFile="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/CustomDNS.txt"
+    if [ -z "$CustomDNSFile" ] && [ -r "$DefaultCustomDNSFile" ]; then
+        CustomDNSFile="$DefaultCustomDNSFile"
+    fi
+    test -r "$CustomDNSFile" || return 0
+    readarray -t customDNS < <(grep -v -E '^(#|$)' "$CustomDNSFile" | sed 's/#.*$//g' | grep -Eo '(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){1,3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])' | xargs -n 1)
+    echo.Cyan "\nRunning nslookup over ${#customDNS[@]} custom DNS:"
+    for DNS in "${customDNS[@]}"; do
+        printf " - %s ... " "$DNS"
+        chkDomain "$domain" "$DNS" filterDetect
+    done
+}
+
 function showDomainIntel() {
     echo.Cyan "\nGet more intels about this domain from:"
     cat <<HEREDOC
@@ -256,4 +270,5 @@ checkNofilterDNS
 checkSecureDNS
 checkAdblockDNS
 checkDefaultDNS
+checkCustomDNS
 showDomainIntel


### PR DESCRIPTION
This commit introduces the ability for users to specify custom DNS servers.

The program will now read from a user-provided file (default: `CustomDNS.txt`), and perform nslookup over these custom DNS servers, in addition to the predefined ones.

Result:
```
$ ./chkdm ipinfo.tw
You are checking domain: ipinfo.tw

Running dig/nslookup over 11 nofilter DNS:
 - AdGuard (94.140.14.140) ... OK! (188.166.199.140)
 - Cloudflare (1.1.1.1) ... OK! (188.166.199.140)
 - dns0.eu (193.110.81.254) ... OK! (188.166.199.140)
 - Freenom World (80.80.81.81) ... OK! (188.166.199.140)
 - Gcore (95.85.95.85) ... OK! (188.166.199.140)
 - Google (8.8.8.8) ... OK! (188.166.199.140)
 - Hinet (168.95.1.1) ... OK! (188.166.199.140)
 - OpenDNS (208.67.222.2) ... OK! (188.166.199.140)
 - Quad9 (9.9.9.10) ... OK! (188.166.199.140)
 - UltraDNS (64.6.64.6) ... OK! (188.166.199.140)
 - Yandex (77.88.8.1) ... OK! (188.166.199.140)

Running dig/nslookup over 11 secure DNS:
 - CleanBrowsing (185.228.168.9) ... OK! (188.166.199.140)
 - Cloudflare (1.1.1.2) ... OK! (188.166.199.140)
 - Comodo (8.26.56.26) ... OK! (188.166.199.140)
 - CONTROL D (76.76.2.1) ... OK! (188.166.199.140)
 - dns0.eu (193.110.81.0) ... OK! (188.166.199.140)
 - OpenDNS (208.67.222.222) ... OK! (188.166.199.140)
 - Quad101 (101.101.101.101) ... OK! (188.166.199.140)
 - Quad9 (9.9.9.9) ... OK! (188.166.199.140)
 - SafeDNS (195.46.39.39) ... OK! (188.166.199.140)
 - UltraDNS (156.154.70.2) ... OK! (188.166.199.140)
 - Yandex (77.88.8.2) ... OK! (188.166.199.140)

Running dig/nslookup over 6 AD(and tracker)-blocking DNS:
 - AdGuard (94.140.14.14) ... OK! (188.166.199.140)
 - AhaDNS (5.2.75.75) ... OK! (188.166.199.140)
 - CONTROL D (76.76.2.2) ... OK! (188.166.199.140)
 - dnsforge.de (176.9.93.198) ... OK! (188.166.199.140)
 - OVPN (192.165.9.157) ... OK! (188.166.199.140)
 - Tiarap (188.166.206.224) ... OK! (188.166.199.140)

Running nslookup over default DNS (127.0.0.1):
 - 127.0.0.1 ... OK! (188.166.199.140)

Running nslookup over 3 custom DNS:
 - 223.5.5.5 ... OK! (188.166.199.140)
 - 172.30.195.241 ... OK! (188.166.199.140)
 - 114.114.114.114 ... OK! (188.166.199.140)

Get more intels about this domain from:
AlienVault Open Threat Exchange
  - https://otx.alienvault.com/indicator/domain/ipinfo.tw
Bitdefender TrafficLight
  - https://trafficlight.bitdefender.com/info/?url=https%3A%2F%2Fipinfo.tw
Google Safe Browsing
  - https://transparencyreport.google.com/safe-browsing/search?url=ipinfo.tw
Kaspersky Threat Intelligence Portal
  - https://opentip.kaspersky.com/ipinfo.tw?tab=web
McAfee SiteAdvisor
  - https://siteadvisor.com/sitereport.html?url=ipinfo.tw
Norton Safe Web
  - https://safeweb.norton.com/report/show?url=ipinfo.tw
OpenDNS
  - https://domain.opendns.com/ipinfo.tw
URLVoid
  - https://www.urlvoid.com/scan/ipinfo.tw/
urlscan.io
  - https://urlscan.io/domain/ipinfo.tw
VirusTotal
  - https://www.virustotal.com/en/domain/ipinfo.tw/information/
Whois.com
  - https://www.whois.com/whois/ipinfo.tw
Yandex Site safety report
  - https://yandex.com/safety/?l10n=en&url=ipinfo.tw
```

When using `CustomDNS.txt` with content below:
```
223.5.5.5
172.30.195.241
114.114.114.114
```

close #12
