### PR TITLE
Make sure macOS on Travis CI use correct bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,10 @@ jobs:
       homebrew:
         packages:
           - bash
+        update: true
     before_script:
+      - echo $PATH
+      - export PATH="$(brew --prefix)/bin:$PATH"
       - echo $PATH
       - brew info bash
       - which bash


### PR DESCRIPTION
Fix Travis CI build failed due to macOS environment issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Travis CI configuration for macOS testing stage
	- Improved Homebrew package management and binary path configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->