### PR TITLE
Add Bash version check for better compatibility and error handling

### DIFF
--- a/chkdm
+++ b/chkdm
@@ -44,6 +44,23 @@ function error() {
     exit 1
 }
 
+if [ -z "$BASH_VERSION" ] || [ -z "$BASH" ]; then
+    error "This script must be run in Bash shell"
+fi
+
+bash_major_version=""
+if [ -n "${BASH_VERSINFO[0]:-}" ] && [ "${BASH_VERSINFO[@]+_}" ]; then
+    bash_major_version="${BASH_VERSINFO[0]}"
+elif [ -n "$BASH_VERSION" ]; then
+    bash_major_version="$(echo "$BASH_VERSION" | cut -d'.' -f1)"
+fi
+
+if [ -z "$bash_major_version" ]; then
+    error "Unable to determine Bash version"
+elif [ "$bash_major_version" -lt 4 ]; then
+    error "This script requires Bash 4.0 or later (detected bash major version: $bash_major_version)"
+fi
+
 if [ "$#" -ne "1" ]; then
     echo.Red "You need to give me just one domain name to run the check!"
     exit 1


### PR DESCRIPTION
Fixes #30

Add a pre-execution check for the Bash version in `chkdm`.

* Add a check for the Bash version at the beginning of the script, just after the `error` function.
* Use the built-in Bash version variable `BASH_VERSINFO` to check if the version is below 4.0.
* Provide a clear error message and exit if the Bash version is below 4.0.
* Output the detected Bash version to assist with troubleshooting.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added version compatibility check for Bash script.
  - Improved script robustness by validating minimum Bash version requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->