### PR TITLE
Remove seems to be dead AhaDNS plaintext Ad-blocking DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The DNS services currently used for sending queries are listed below:
 | **No-filter** DNS                              | **Secure** DNS                                   | **Ad/Tracker-blocking** DNS                 |
 | ---------------------------------------------- | ------------------------------------------------ | ------------------------------------------- |
 | [AdGuard][AdGuard] (`94.140.14.140`)           | [CleanBrowsing][CleanBrowsing] (`185.228.168.9`) | [AdGuard][AdGuard] (`94.140.14.14`)         |
-| [Cloudflare][Cloudflare] (`1.1.1.1`)           | [Cloudflare][Cloudflare] (`1.1.1.2`)             | [AhaDNS][AhaDNS] (`5.2.75.75`)              |
-| [dns0.eu][dns0.eu] (`193.110.81.254`)          | [Comodo][Comodo] (`8.26.56.26`)                  | [CONTROL D][CONTROL D] (`76.76.2.2`)        |
-| [Freenom World][Freenom World] (`80.80.81.81`) | [CONTROL D][CONTROL D] (`76.76.2.1`)             | [dnsforge.de][dnsforge.de] (`176.9.93.198`) |
-| [Gcore][Gcore] (`95.85.95.85`)                 | [dns0.eu][dns0.eu] (`193.110.81.0`)              | [OVPN][OVPN] (`192.165.9.157`)              |
-| [Google][Google] (`8.8.8.8`)                   | [UltraDNS][UltraDNS] (`156.154.70.2`)            | [Tiarap][Tiarap] (`188.166.206.224`)        |
+| [Cloudflare][Cloudflare] (`1.1.1.1`)           | [Cloudflare][Cloudflare] (`1.1.1.2`)             | [CONTROL D][CONTROL D] (`76.76.2.2`)        |
+| [dns0.eu][dns0.eu] (`193.110.81.254`)          | [Comodo][Comodo] (`8.26.56.26`)                  | [dnsforge.de][dnsforge.de] (`176.9.93.198`) |
+| [Freenom World][Freenom World] (`80.80.81.81`) | [CONTROL D][CONTROL D] (`76.76.2.1`)             | [OVPN][OVPN] (`192.165.9.157`)              |
+| [Gcore][Gcore] (`95.85.95.85`)                 | [dns0.eu][dns0.eu] (`193.110.81.0`)              | [Tiarap][Tiarap] (`188.166.206.224`)        |
+| [Google][Google] (`8.8.8.8`)                   | [UltraDNS][UltraDNS] (`156.154.70.2`)            |                                             |
 | [Hinet][Hinet] (`168.95.1.1`)                  | [OpenDNS][OpenDNS] (`208.67.222.222`)            |                                             |
 | [UltraDNS][UltraDNS] (`64.6.64.6`)             | [Quad101][Quad101] (`101.101.101.101`)           |                                             |
 | [OpenDNS][OpenDNS] (`208.67.222.2`)            | [Quad9][Quad9] (`9.9.9.9`)                       |                                             |
@@ -117,7 +117,6 @@ There are also some malicious domains blocking services that don't directly prov
 GPL-3.0 (GNU GENERAL PUBLIC LICENSE Version 3)
 
 [AdGuard]: https://adguard-dns.com/
-[AhaDNS]: https://ahadns.com/
 [CleanBrowsing]: https://cleanbrowsing.org/
 [Cloudflare]: https://1.1.1.1/family/
 [Comodo]: https://www.comodo.com/secure-dns/

--- a/chkdm
+++ b/chkdm
@@ -93,7 +93,6 @@ secureDNS[Quad9]="9.9.9.9"
 secureDNS[Yandex]="77.88.8.2"
 
 adblockDNS[AdGuard]="94.140.14.14"
-adblockDNS[AhaDNS]="5.2.75.75"
 adblockDNS[CONTROL D]="76.76.2.2"
 adblockDNS[dnsforge.de]="176.9.93.198"
 adblockDNS[OVPN]="192.165.9.157"


### PR DESCRIPTION
Their plaintext DNS service seems to have stopped for a while.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated DNS services table in README.md
	- Removed AhaDNS entry from the Ad/Tracker-blocking DNS column

- **Chores**
	- Cleaned up DNS service listings
	- Removed specific DNS provider entry from configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->