### PR TITLE
Remove unstable Freenom World DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ The DNS services currently used for sending queries are listed below:
 | [AdGuard][AdGuard] (`94.140.14.140`)           | [CleanBrowsing][CleanBrowsing] (`185.228.168.9`) | [AdGuard][AdGuard] (`94.140.14.14`)         |
 | [Cloudflare][Cloudflare] (`1.1.1.1`)           | [Cloudflare][Cloudflare] (`1.1.1.2`)             | [CONTROL D][CONTROL D] (`76.76.2.2`)        |
 | [dns0.eu][dns0.eu] (`193.110.81.254`)          | [Comodo][Comodo] (`8.26.56.26`)                  | [dnsforge.de][dnsforge.de] (`176.9.93.198`) |
-| [Freenom World][Freenom World] (`80.80.81.81`) | [CONTROL D][CONTROL D] (`76.76.2.1`)             | [OVPN][OVPN] (`192.165.9.157`)              |
-| [Gcore][Gcore] (`95.85.95.85`)                 | [dns0.eu][dns0.eu] (`193.110.81.0`)              | [Tiarap][Tiarap] (`188.166.206.224`)        |
-| [Google][Google] (`8.8.8.8`)                   | [UltraDNS][UltraDNS] (`156.154.70.2`)            |                                             |
-| [Hinet][Hinet] (`168.95.1.1`)                  | [OpenDNS][OpenDNS] (`208.67.222.222`)            |                                             |
-| [UltraDNS][UltraDNS] (`64.6.64.6`)             | [Quad101][Quad101] (`101.101.101.101`)           |                                             |
-| [OpenDNS][OpenDNS] (`208.67.222.2`)            | [Quad9][Quad9] (`9.9.9.9`)                       |                                             |
-| [Quad9][Quad9] (`9.9.9.10`)                    | [SafeDNS][SafeDNS] (`195.46.39.39`)              |                                             |
-| [Yandex][Yandex] (`77.88.8.1`)                 | [Yandex][Yandex] (`77.88.8.2`)                   |                                             |
+| [Gcore][Gcore] (`95.85.95.85`)                 | [CONTROL D][CONTROL D] (`76.76.2.1`)             | [OVPN][OVPN] (`192.165.9.157`)              |
+| [Google][Google] (`8.8.8.8`)                   | [dns0.eu][dns0.eu] (`193.110.81.0`)              | [Tiarap][Tiarap] (`188.166.206.224`)        |
+| [Hinet][Hinet] (`168.95.1.1`)                  | [UltraDNS][UltraDNS] (`156.154.70.2`)            |                                             |
+| [UltraDNS][UltraDNS] (`64.6.64.6`)             | [OpenDNS][OpenDNS] (`208.67.222.222`)            |                                             |
+| [OpenDNS][OpenDNS] (`208.67.222.2`)            | [Quad101][Quad101] (`101.101.101.101`)           |                                             |
+| [Quad9][Quad9] (`9.9.9.10`)                    | [Quad9][Quad9] (`9.9.9.9`)                       |                                             |
+| [Yandex][Yandex] (`77.88.8.1`)                 | [SafeDNS][SafeDNS] (`195.46.39.39`)              |                                             |
+|                                                | [Yandex][Yandex] (`77.88.8.2`)                   |                                             |
 
 After checking the domain, `chkdomain` provides direct links to the following intelligence services for more information:
 
@@ -123,7 +123,6 @@ GPL-3.0 (GNU GENERAL PUBLIC LICENSE Version 3)
 [CONTROL D]: https://controld.com/
 [dns0.eu]: https://www.dns0.eu/
 [dnsforge.de]: https://dnsforge.de/
-[Freenom World]: https://www.freenom.world/
 [Gcore]: https://gcore.com/public-dns
 [Google]: https://developers.google.com/speed/public-dns/
 [Hinet]: https://dns.hinet.net/

--- a/chkdm
+++ b/chkdm
@@ -71,7 +71,6 @@ declare -A nofilterDNS secureDNS adblockDNS
 nofilterDNS[AdGuard]="94.140.14.140"
 nofilterDNS[Cloudflare]="1.1.1.1"
 nofilterDNS[dns0.eu]="193.110.81.254"
-nofilterDNS[Freenom World]="80.80.81.81"
 nofilterDNS[Gcore]="95.85.95.85"
 nofilterDNS[Google]="8.8.8.8"
 nofilterDNS[Hinet]="168.95.1.1"


### PR DESCRIPTION
It's somehow unstable for a while.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated DNS service listings in README.md
	- Removed Freenom World DNS entry
	- Added new DNS services like Tiarap and SafeDNS
	- Reintroduced and repositioned several DNS providers in different categories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->