### PR TITLE
Add Palo Alto URL Filtering intel deep link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ After checking the domain, `chkdomain` provides direct links to the following in
 - [McAfee SiteAdvisor](https://siteadvisor.com/)
 - [Norton Safe Web](https://safeweb.norton.com/)
 - [OpenDNS](https://domain.opendns.com/)
+- [Palo Alto Networks URL Filtering](https://urlfiltering.paloaltonetworks.com/single_cr/)
 - [URLVoid](https://www.urlvoid.com/scan/)
 - [urlscan.io](https://urlscan.io/)
 - [VirusTotal](https://www.virustotal.com/gui/home/url)
 - [Whois.com](https://www.whois.com/whois/)
 - [Yandex Site safety report](https://yandex.com/safety/)
+
+The Palo Alto Networks URL Filtering link deep-links to the undocumented `single_cr` change request endpoint so the queried domain is prefilled when the `url` query parameter is provided (e.g., `.../single_cr/?url=example.com`). Palo Alto Networks may modify that flow or introduce additional verification without notice; fall back to the manual form listed under Additional Resources if the shortcut stops working.
 
 If you'd like to build up your own secure DNS, check out the [threat-hostlist](https://github.com/PeterDaveHello/threat-hostlist) repository. It contains many different threat-blocking blocklists to help you create a secure DNS service for your home, office, or elsewhere.
 
@@ -103,13 +106,13 @@ Please be aware that domain names with records such as `0.0.0.0` or `127.0.0.1` 
 
 ## Additional Resources
 
-There are also some malicious domains blocking services that don't directly provide DNS services and can't be queried via the HTTP GET method. As a result, we are unable to integrate them or list their corresponding query URLs in the check results. However, since they are provided by leading security companies and offer a web interface that allows you to manually submit a domain to retrieve the related intelligence, they are worth mentioning. The services are listed below:
+There are also some malicious domains blocking services that don't directly provide DNS services and can't be queried via the HTTP GET method. As a result, we are unable to integrate them or list their corresponding query URLs in the check results. However, since they are provided by leading security companies and offer a web interface that allows you to manually submit a domain to retrieve the related intelligence, they are worth mentioning. The Palo Alto Networks entry also serves as the manual fallback when the deep link cannot prefill the domain. The services are listed below:
 
 - FortiGuard Web Filter Lookup
   - <https://www.fortiguard.com/webfilter>
 - Trend Micro Site Safety Center
   - <https://global.sitesafety.trendmicro.com>
-- Palo Alto Networks URL filtering
+- Palo Alto Networks URL Filtering
   - <https://urlfiltering.paloaltonetworks.com/>
 
 ## License

--- a/chkdm
+++ b/chkdm
@@ -276,6 +276,8 @@ Norton Safe Web
   - https://safeweb.norton.com/report/show?url=$domain
 OpenDNS
   - https://domain.opendns.com/$domain
+Palo Alto Networks URL Filtering
+  - https://urlfiltering.paloaltonetworks.com/single_cr/?url=$domain
 URLVoid
   - https://www.urlvoid.com/scan/$domain/
 urlscan.io


### PR DESCRIPTION
### **User description**
Extend the intel list with a Palo Alto URL Filtering entry that opens the single_cr deep link with the queried domain prefilled.

The public Test A Site page on urlfiltering.paloaltonetworks.com does not support pre-populating the form via GET parameters, so this relies on an undocumented change-request endpoint that may change or start requiring verification without notice.

GitHub Copilot Summary:

> This pull request adds a new external threat intelligence resource to the `chkdm` file, expanding the available domain reputation check options.
> 
> New threat intelligence resource:
> 
> * Added "Palo Alto URL Filtering" with a link to check domain reputation via Palo Alto Networks.


___

### **PR Type**
Enhancement


___

### **Description**
- Add Palo Alto URL Filtering intel link to domain reputation checks

- Uses undocumented single_cr endpoint with domain prefilling

- Extends available threat intelligence resources


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Intel List"] -- "Add Entry" --> B["Palo Alto URL Filtering"]
  B -- "Links to" --> C["urlfiltering.paloaltonetworks.com/single_cr"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chkdm</strong><dd><code>Add Palo Alto URL Filtering intel resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chkdm

<ul><li>Added new "Palo Alto URL Filtering" entry to intel list<br> <li> Configured with deep link to single_cr endpoint with domain parameter<br> <li> Positioned alphabetically between OpenDNS and URLVoid entries</ul>


</details>


  </td>
  <td><a href="https://github.com/PeterDaveHello/chkdomain/pull/41/files#diff-877eec3093a6bf1456ea0f137fa4f43831aa132a834439888e6b7cb323917d52">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain intelligence now includes Palo Alto Networks URL Filtering entries with deep-link URLs for quick domain checks.

* **Documentation**
  * Added resource link and note explaining the Palo Alto deep-link may prefill the domain and could change; use the manual form as a fallback.
  * Updated Additional Resources and bottom resources to list Palo Alto Networks URL Filtering as a manual fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->